### PR TITLE
Add URL scraping import flow for demo submissions

### DIFF
--- a/client/src/pages/submit-demo.tsx
+++ b/client/src/pages/submit-demo.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -17,7 +17,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
-import { Upload, Link as LinkIcon, Type, FileText, Video } from "lucide-react";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Upload, Link as LinkIcon, Type, FileText, Video, Globe, Sparkles, Loader2 } from "lucide-react";
 import type { UploadResult } from "@uppy/core";
 
 // Feature flag - set to true to use Cloudflare Stream
@@ -32,12 +33,49 @@ const submitDemoSchema = z.object({
 
 type SubmitDemoForm = z.infer<typeof submitDemoSchema>;
 
+type SubmissionMode = "upload" | "import";
+
+type ScrapedVideoSource = {
+  url: string;
+  type: "file" | "hls" | "unknown";
+  label?: string;
+  mimeType?: string;
+};
+
+type ScrapeResponse = {
+  originalUrl: string;
+  canonicalUrl?: string;
+  title?: string;
+  description?: string;
+  thumbnailUrl?: string;
+  tags: string[];
+  videoSources: ScrapedVideoSource[];
+  durationSeconds?: number;
+};
+
+type SubmitMutationInput = SubmitDemoForm & {
+  mode: SubmissionMode;
+  tags: string[];
+  videoPath?: string;
+  videoId?: string;
+  importUrl?: string;
+  selectedVideoUrl?: string;
+  thumbnailUrl?: string;
+};
+
 export default function SubmitDemo() {
   const [videoPath, setVideoPath] = useState<string>("");
   const [videoId, setVideoId] = useState<string>("");
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [isUploading, setIsUploading] = useState(false);
   const [tags, setTags] = useState<string[]>([]);
+  const [submissionMode, setSubmissionMode] = useState<SubmissionMode>("upload");
+  const [importUrl, setImportUrl] = useState("");
+  const [isScraping, setIsScraping] = useState(false);
+  const [scrapeResult, setScrapeResult] = useState<ScrapeResponse | null>(null);
+  const [scrapedVideos, setScrapedVideos] = useState<ScrapedVideoSource[]>([]);
+  const [selectedScrapedVideo, setSelectedScrapedVideo] = useState<string>("");
+  const [scrapeError, setScrapeError] = useState<string | null>(null);
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const { addUpload } = useUploadQueue();
@@ -53,30 +91,85 @@ export default function SubmitDemo() {
   });
 
   const submitMutation = useMutation({
-    mutationFn: async (data: SubmitDemoForm & { videoPath?: string; videoId?: string }) => {
-      // For S3 uploads, we submit with videoPath
-      // For Cloudflare uploads, the video is already created
-      if (USE_CLOUDFLARE_STREAM) {
-        // For Cloudflare, the video is already created during upload
-        // We might need to update metadata if needed
-        return { success: true, videoId: data.videoId };
-      } else {
-        return await apiRequest("POST", "/api/videos", data);
+    mutationFn: async (data: SubmitMutationInput) => {
+      const {
+        mode,
+        tags: submittedTags,
+        importUrl: importSource,
+        selectedVideoUrl,
+        thumbnailUrl,
+        videoPath: submittedVideoPath,
+        videoId: submittedVideoId,
+        ...formValues
+      } = data;
+
+      if (mode === "import") {
+        if (!importSource) {
+          throw new Error("A source URL is required to import a demo.");
+        }
+
+        const response = await apiRequest("POST", "/api/videos/import-from-url", {
+          sourceUrl: importSource,
+          preferredVideoUrl: selectedVideoUrl,
+          overrides: {
+            title: formValues.title,
+            description: formValues.description,
+            productUrl: formValues.productUrl,
+            thumbnailUrl,
+          },
+          tags: submittedTags,
+        });
+
+        return await response.json();
       }
-    },
-    onSuccess: () => {
-      toast({
-        title: "Success!",
-        description: "Your demo has been submitted successfully.",
+
+      if (USE_CLOUDFLARE_STREAM) {
+        return { success: true, videoId: submittedVideoId };
+      }
+
+      if (!submittedVideoPath) {
+        throw new Error("Please upload a video before submitting your demo.");
+      }
+
+      const response = await apiRequest("POST", "/api/videos", {
+        ...formValues,
+        videoPath: submittedVideoPath,
+        tags: submittedTags,
       });
+
+      return await response.json();
+    },
+    onSuccess: (result, variables) => {
+      if (variables.mode === "import") {
+        const createdTitle = result?.video?.title ?? variables.title;
+        toast({
+          title: "Demo imported!",
+          description: createdTitle
+            ? `We created “${createdTitle}” from your link.`
+            : "We created a new demo from your link.",
+        });
+      } else {
+        toast({
+          title: "Success!",
+          description: "Your demo has been submitted successfully.",
+        });
+      }
+
       form.reset();
       setVideoPath("");
       setVideoId("");
+      setSelectedFile(null);
       setTags([]);
+      setScrapeResult(null);
+      setScrapedVideos([]);
+      setSelectedScrapedVideo("");
+      setImportUrl("");
+      setScrapeError(null);
+
       queryClient.invalidateQueries({ queryKey: ["/api/videos/top"] });
       queryClient.invalidateQueries({ queryKey: ["/api/user/videos"] });
     },
-    onError: (error) => {
+    onError: (error, variables) => {
       if (isUnauthorizedError(error)) {
         toast({
           title: "Unauthorized",
@@ -86,13 +179,70 @@ export default function SubmitDemo() {
         setTimeout(() => redirectToSignInClient(), 500);
         return;
       }
+
+      const fallbackMessage =
+        variables?.mode === "import"
+          ? "Failed to import a demo from that URL. Please try again or choose a different page."
+          : "Failed to submit demo. Please try again.";
+
+      const message = error instanceof Error && error.message ? error.message : fallbackMessage;
+      console.error("Error submitting demo:", error);
+
       toast({
         title: "Error",
-        description: "Failed to submit demo. Please try again.",
+        description: message,
         variant: "destructive",
       });
     },
   });
+
+  useEffect(() => {
+    if (submissionMode === "upload") {
+      setImportUrl("");
+      setScrapeResult(null);
+      setScrapedVideos([]);
+      setSelectedScrapedVideo("");
+      setScrapeError(null);
+      setIsScraping(false);
+    } else {
+      setVideoPath("");
+      setVideoId("");
+      setSelectedFile(null);
+    }
+  }, [submissionMode]);
+
+  const importSelectedVideoUrl = useMemo(() => {
+    if (selectedScrapedVideo) {
+      return selectedScrapedVideo;
+    }
+    return scrapedVideos[0]?.url;
+  }, [selectedScrapedVideo, scrapedVideos]);
+
+  const formattedScrapeDuration = useMemo(() => {
+    if (!scrapeResult?.durationSeconds || scrapeResult.durationSeconds <= 0) {
+      return null;
+    }
+    const minutes = Math.floor(scrapeResult.durationSeconds / 60);
+    const seconds = scrapeResult.durationSeconds % 60;
+    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+  }, [scrapeResult?.durationSeconds]);
+
+  const describeVideoSource = (video: ScrapedVideoSource, index: number) => {
+    const baseLabel = video.label?.trim() || `Video ${index + 1}`;
+    const typeLabel = video.type === "hls" ? "HLS" : "File";
+    let host: string | undefined;
+    try {
+      host = new URL(video.url).hostname;
+    } catch {
+      host = undefined;
+    }
+
+    return host ? `${baseLabel} • ${typeLabel} • ${host}` : `${baseLabel} • ${typeLabel}`;
+  };
+
+  const isSubmitDisabled = submissionMode === "import"
+    ? submitMutation.isPending || isScraping || !importUrl.trim()
+    : submitMutation.isPending || isUploading || (USE_CLOUDFLARE_STREAM ? !selectedFile : !videoPath);
 
   const handleGetUploadParameters = async () => {
     try {
@@ -112,6 +262,96 @@ export default function SubmitDemo() {
         setTimeout(() => redirectToSignInClient(), 500);
       }
       throw error;
+    }
+  };
+
+  const handleScrapeUrl = async () => {
+    const normalizedUrl = importUrl.trim();
+    if (!normalizedUrl) {
+      toast({
+        title: "URL required",
+        description: "Please enter a product or landing page URL to scan.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setIsScraping(true);
+    setScrapeError(null);
+
+    try {
+      const response = await apiRequest("POST", "/api/videos/scrape-url", { url: normalizedUrl });
+      const data: ScrapeResponse = await response.json();
+
+      setImportUrl(normalizedUrl);
+      setScrapeResult(data);
+      setScrapedVideos(data.videoSources ?? []);
+      setSelectedScrapedVideo(data.videoSources?.[0]?.url ?? "");
+
+      if (data.title) {
+        form.setValue("title", data.title, { shouldDirty: true, shouldValidate: true });
+      }
+      if (data.description) {
+        form.setValue("description", data.description, { shouldDirty: true, shouldValidate: true });
+      }
+      const resolvedProductUrl = data.canonicalUrl ?? normalizedUrl;
+      form.setValue("productUrl", resolvedProductUrl, { shouldDirty: true, shouldValidate: true });
+
+      if (data.tags?.length) {
+        setTags(prev => {
+          const combined = new Set(prev);
+          for (const tag of data.tags) {
+            if (typeof tag === "string" && tag.trim()) {
+              const trimmed = tag.trim();
+              combined.add(trimmed.slice(0, 50));
+            }
+          }
+          return Array.from(combined).slice(0, 10);
+        });
+      }
+
+      if (!data.videoSources?.length) {
+        const message = "We couldn't find any downloadable videos on that page. You can try submitting anyway or choose a different URL.";
+        setScrapeError(message);
+        toast({
+          title: "No videos detected",
+          description: message,
+        });
+      } else {
+        setScrapeError(null);
+        toast({
+          title: "Page scanned!",
+          description:
+            data.videoSources.length === 1
+              ? "Found 1 video and pre-filled your details."
+              : `Found ${data.videoSources.length} videos. Choose the one you want to import.`,
+        });
+      }
+    } catch (error) {
+      console.error("Failed to scrape URL:", error);
+      setScrapeResult(null);
+      setScrapedVideos([]);
+      setSelectedScrapedVideo("");
+
+      if (isUnauthorizedError(error as Error)) {
+        toast({
+          title: "Unauthorized",
+          description: "You are logged out. Logging in again...",
+          variant: "destructive",
+        });
+        setTimeout(() => redirectToSignInClient(), 500);
+        return;
+      }
+
+      const message = error instanceof Error && error.message ? error.message : "Failed to scan the provided URL.";
+      setScrapeError(message);
+      toast({
+        title: "Scrape failed",
+        description: message,
+        variant: "destructive",
+      });
+    } finally {
+      setIsScraping(false);
     }
   };
 
@@ -153,14 +393,30 @@ export default function SubmitDemo() {
   };
 
   const onSubmit = (data: SubmitDemoForm) => {
-    console.log('Form submitted with data:', data);
-    console.log('Selected file:', selectedFile);
-    console.log('USE_CLOUDFLARE_STREAM:', USE_CLOUDFLARE_STREAM);
-    
+    if (submissionMode === "import") {
+      const normalizedUrl = importUrl.trim();
+      if (!normalizedUrl) {
+        toast({
+          title: "URL required",
+          description: "Please enter a URL to import.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      submitMutation.mutate({
+        ...data,
+        mode: "import",
+        tags,
+        importUrl: normalizedUrl,
+        selectedVideoUrl: importSelectedVideoUrl,
+        thumbnailUrl: scrapeResult?.thumbnailUrl,
+      });
+      return;
+    }
+
     if (USE_CLOUDFLARE_STREAM) {
-      // For Cloudflare Stream - add to background upload queue
       if (!selectedFile) {
-        console.log('No file selected');
         toast({
           title: "Video required",
           description: "Please select a video before submitting.",
@@ -169,10 +425,7 @@ export default function SubmitDemo() {
         return;
       }
 
-      console.log('Adding to upload queue...');
-      
       try {
-        // Add to upload queue and reset form
         addUpload({
           file: selectedFile,
           title: data.title,
@@ -186,12 +439,9 @@ export default function SubmitDemo() {
           description: "Your video has been added to the upload queue. You can continue using the site while it uploads in the background.",
         });
 
-        // Reset form
         form.reset();
         setSelectedFile(null);
         setTags([]);
-        
-        console.log('Upload queued successfully');
       } catch (error) {
         console.error('Error adding to upload queue:', error);
         toast({
@@ -200,24 +450,25 @@ export default function SubmitDemo() {
           variant: "destructive",
         });
       }
-      
-    } else {
-      // Original S3 flow
-      if (!videoPath) {
-        toast({
-          title: "Video required",
-          description: "Please upload a video before submitting.",
-          variant: "destructive",
-        });
-        return;
-      }
 
-      submitMutation.mutate({
-        ...data,
-        videoPath,
-        tags,
-      });
+      return;
     }
+
+    if (!videoPath) {
+      toast({
+        title: "Video required",
+        description: "Please upload a video before submitting.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    submitMutation.mutate({
+      ...data,
+      mode: "upload",
+      videoPath,
+      tags,
+    });
   };
 
   return (
@@ -243,82 +494,211 @@ export default function SubmitDemo() {
           </CardHeader>
           <CardContent>
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-              {/* Video Upload */}
-              <div className="space-y-2">
-                <Label htmlFor="video" className="flex items-center">
-                  <Upload className="mr-2 h-4 w-4" />
-                  Video Upload *
-                </Label>
-                <div className="border-2 border-dashed border-border rounded-lg p-8 text-center">
-                  {(USE_CLOUDFLARE_STREAM ? selectedFile : videoPath) ? (
-                    <div className="space-y-2">
-                      <div className="w-16 h-16 bg-accent/10 rounded-lg flex items-center justify-center mx-auto">
-                        <Video className="h-8 w-8 text-accent" />
-                      </div>
-                      <p className="text-foreground font-medium">Video uploaded successfully!</p>
-                      <p className="text-sm text-muted-foreground">Ready to submit your demo</p>
-                    </div>
-                  ) : (
-                    <div className="space-y-4">
-                      <div className="w-16 h-16 bg-muted rounded-lg flex items-center justify-center mx-auto">
-                        <Upload className="h-8 w-8 text-muted-foreground" />
-                      </div>
-                      <div>
-                        <p className="text-foreground font-medium mb-2">Upload your demo video</p>
-                        <p className="text-sm text-muted-foreground mb-4">
-                          MP4 format, max 100MB. Keep it under 60 seconds for best engagement.
-                        </p>
-                        {USE_CLOUDFLARE_STREAM ? (
-                          <div className="space-y-3">
-                            <input
-                              type="file"
-                              accept="video/*"
-                              onChange={(e) => {
-                                const file = e.target.files?.[0];
-                                if (file) {
-                                  // Validate file size (100MB)
-                                  if (file.size > 100 * 1024 * 1024) {
-                                    toast({
-                                      title: "File too large",
-                                      description: "Maximum file size is 100MB",
-                                      variant: "destructive",
-                                    });
-                                    return;
-                                  }
-                                  setSelectedFile(file);
-                                }
-                              }}
-                              className="hidden"
-                              id="video-upload"
-                            />
-                            <label
-                              htmlFor="video-upload"
-                              className="flex items-center justify-center px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 cursor-pointer transition-colors"
-                            >
-                              <Upload className="mr-2 h-4 w-4" />
-                              {selectedFile ? 'Change Video File' : 'Choose Video File'}
-                            </label>
-                            {selectedFile && (
-                              <div className="text-sm text-muted-foreground">
-                                Selected: {selectedFile.name} ({(selectedFile.size / (1024 * 1024)).toFixed(1)} MB)
+              {/* Video Source */}
+              <div className="space-y-4">
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    type="button"
+                    variant={submissionMode === "upload" ? "default" : "outline"}
+                    onClick={() => setSubmissionMode("upload")}
+                    className="flex items-center gap-2"
+                  >
+                    <Upload className="h-4 w-4" />
+                    Upload a video
+                  </Button>
+                  <Button
+                    type="button"
+                    variant={submissionMode === "import" ? "default" : "outline"}
+                    onClick={() => setSubmissionMode("import")}
+                    className="flex items-center gap-2"
+                  >
+                    <Globe className="h-4 w-4" />
+                    Import from URL
+                  </Button>
+                </div>
+                <div className="space-y-2">
+                  <Label
+                    htmlFor={submissionMode === "import" ? "import-url" : "video-upload"}
+                    className="flex items-center"
+                  >
+                    {submissionMode === "import" ? (
+                      <Globe className="mr-2 h-4 w-4" />
+                    ) : (
+                      <Upload className="mr-2 h-4 w-4" />
+                    )}
+                    {submissionMode === "import" ? "Import from URL *" : "Video Upload *"}
+                  </Label>
+                  <div className={`border-2 border-dashed border-border rounded-lg p-8 ${submissionMode === "import" ? "text-left" : "text-center"}`}>
+                    {submissionMode === "import" ? (
+                      <div className="space-y-5">
+                        <div className="space-y-1 text-center sm:text-left">
+                          <p className="flex items-center justify-center gap-2 text-base font-medium text-foreground sm:justify-start">
+                            <Sparkles className="h-4 w-4 text-accent" />
+                            Pull demo details from a web page
+                          </p>
+                          <p className="text-sm text-muted-foreground">
+                            We'll scan the page for descriptions, metadata, and downloadable demo videos.
+                          </p>
+                        </div>
+                        <div className="flex flex-col gap-3 sm:flex-row">
+                          <Input
+                            id="import-url"
+                            type="url"
+                            placeholder="https://your-product.com/demo"
+                            value={importUrl}
+                            onChange={(e) => setImportUrl(e.target.value)}
+                          />
+                          <Button
+                            type="button"
+                            onClick={handleScrapeUrl}
+                            disabled={isScraping}
+                            className="w-full sm:w-auto"
+                          >
+                            {isScraping ? (
+                              <>
+                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                Scanning...
+                              </>
+                            ) : (
+                              <>
+                                <Sparkles className="mr-2 h-4 w-4" />
+                                Scan page
+                              </>
+                            )}
+                          </Button>
+                        </div>
+                        {scrapeError && (
+                          <p className="text-sm text-destructive">{scrapeError}</p>
+                        )}
+                        {scrapeResult && (
+                          <div className="space-y-4">
+                            {(scrapeResult.thumbnailUrl || scrapeResult.title || scrapeResult.description) && (
+                              <div className="flex flex-col gap-3 rounded-lg border border-border/60 bg-muted/40 p-4 sm:flex-row sm:items-center">
+                                {scrapeResult.thumbnailUrl && (
+                                  <img
+                                    src={scrapeResult.thumbnailUrl}
+                                    alt="Detected thumbnail"
+                                    className="h-16 w-16 rounded-md object-cover border border-border/70"
+                                  />
+                                )}
+                                <div className="space-y-1 text-sm">
+                                  {scrapeResult.title && (
+                                    <p className="font-medium text-foreground">{scrapeResult.title}</p>
+                                  )}
+                                  {formattedScrapeDuration && (
+                                    <p className="text-muted-foreground">Estimated duration: {formattedScrapeDuration}</p>
+                                  )}
+                                  {scrapeResult.description && (
+                                    <p className="text-muted-foreground line-clamp-2">{scrapeResult.description}</p>
+                                  )}
+                                </div>
                               </div>
                             )}
+                            <div className="space-y-2">
+                              <Label className="text-sm font-medium text-foreground">Detected videos</Label>
+                              {scrapedVideos.length > 0 ? (
+                                <Select
+                                  value={importSelectedVideoUrl ?? ""}
+                                  onValueChange={(value) => setSelectedScrapedVideo(value)}
+                                >
+                                  <SelectTrigger>
+                                    <SelectValue placeholder="Select a video to import" />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {scrapedVideos.map((videoSource, index) => (
+                                      <SelectItem key={videoSource.url} value={videoSource.url}>
+                                        {describeVideoSource(videoSource, index)}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              ) : (
+                                <p className="text-sm text-muted-foreground">
+                                  {isScraping ? "Scanning for videos..." : "No downloadable videos detected yet. Try scanning a different page."}
+                                </p>
+                              )}
+                            </div>
                           </div>
-                        ) : (
-                          <ObjectUploader
-                            maxNumberOfFiles={1}
-                            maxFileSize={100 * 1024 * 1024} // 100MB
-                            onGetUploadParameters={handleGetUploadParameters}
-                            onComplete={handleUploadComplete}
-                            buttonClassName="bg-primary text-primary-foreground"
-                          >
-                            <Upload className="mr-2 h-4 w-4" />
-                            Choose Video File
-                          </ObjectUploader>
+                        )}
+                        {!scrapeResult && !scrapeError && (
+                          <p className="text-sm text-muted-foreground">
+                            Paste a product or landing page URL and we'll pre-fill your demo details automatically.
+                          </p>
                         )}
                       </div>
-                    </div>
-                  )}
+                    ) : (
+                      <div className="space-y-4 text-center">
+                        {(USE_CLOUDFLARE_STREAM ? selectedFile : videoPath) ? (
+                          <div className="space-y-2">
+                            <div className="w-16 h-16 bg-accent/10 rounded-lg flex items-center justify-center mx-auto">
+                              <Video className="h-8 w-8 text-accent" />
+                            </div>
+                            <p className="text-foreground font-medium">Video ready to submit!</p>
+                            <p className="text-sm text-muted-foreground">You're all set—review your details below.</p>
+                          </div>
+                        ) : (
+                          <>
+                            <div className="w-16 h-16 bg-muted rounded-lg flex items-center justify-center mx-auto">
+                              <Upload className="h-8 w-8 text-muted-foreground" />
+                            </div>
+                            <div>
+                              <p className="text-foreground font-medium mb-2">Upload your demo video</p>
+                              <p className="text-sm text-muted-foreground mb-4">
+                                MP4 format, max 100MB. Keep it under 60 seconds for best engagement.
+                              </p>
+                              {USE_CLOUDFLARE_STREAM ? (
+                                <div className="space-y-3">
+                                  <input
+                                    type="file"
+                                    accept="video/*"
+                                    onChange={(e) => {
+                                      const file = e.target.files?.[0];
+                                      if (file) {
+                                        if (file.size > 100 * 1024 * 1024) {
+                                          toast({
+                                            title: "File too large",
+                                            description: "Maximum file size is 100MB",
+                                            variant: "destructive",
+                                          });
+                                          return;
+                                        }
+                                        setSelectedFile(file);
+                                      }
+                                    }}
+                                    className="hidden"
+                                    id="video-upload"
+                                  />
+                                  <label
+                                    htmlFor="video-upload"
+                                    className="flex items-center justify-center px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 cursor-pointer transition-colors"
+                                  >
+                                    <Upload className="mr-2 h-4 w-4" />
+                                    {selectedFile ? "Change Video File" : "Choose Video File"}
+                                  </label>
+                                  {selectedFile && (
+                                    <div className="text-sm text-muted-foreground">
+                                      Selected: {selectedFile.name} ({(selectedFile.size / (1024 * 1024)).toFixed(1)} MB)
+                                    </div>
+                                  )}
+                                </div>
+                              ) : (
+                                <ObjectUploader
+                                  maxNumberOfFiles={1}
+                                  maxFileSize={100 * 1024 * 1024}
+                                  onGetUploadParameters={handleGetUploadParameters}
+                                  onComplete={handleUploadComplete}
+                                  buttonClassName="bg-primary text-primary-foreground"
+                                >
+                                  <Upload className="mr-2 h-4 w-4" />
+                                  Choose Video File
+                                </ObjectUploader>
+                              )}
+                            </div>
+                          </>
+                        )}
+                      </div>
+                    )}
+                  </div>
                 </div>
               </div>
 
@@ -397,23 +777,21 @@ export default function SubmitDemo() {
               <Button
                 type="submit"
                 className="w-full bg-primary text-primary-foreground"
-                disabled={submitMutation.isPending || isUploading || (USE_CLOUDFLARE_STREAM ? !selectedFile : !videoPath)}
+                disabled={isSubmitDisabled}
                 data-testid="button-submit"
-                onClick={(e) => {
-                  console.log('Submit button clicked!');
-                  console.log('Form valid:', form.formState.isValid);
-                  console.log('Selected file:', selectedFile);
-                  console.log('Button disabled:', submitMutation.isPending || isUploading || (USE_CLOUDFLARE_STREAM ? !selectedFile : !videoPath));
-                }}
               >
                 {submitMutation.isPending ? (
-                  "Submitting..."
-                ) : isUploading ? (
+                  submissionMode === "import" ? "Importing..." : "Submitting..."
+                ) : isUploading && submissionMode === "upload" ? (
                   "Processing Upload..."
                 ) : (
                   <>
-                    <Upload className="mr-2 h-4 w-4" />
-                    Submit Demo
+                    {submissionMode === "import" ? (
+                      <Sparkles className="mr-2 h-4 w-4" />
+                    ) : (
+                      <Upload className="mr-2 h-4 w-4" />
+                    )}
+                    {submissionMode === "import" ? "Import Demo" : "Submit Demo"}
                   </>
                 )}
               </Button>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -7,6 +7,7 @@ import { ObjectPermission } from "./objectAcl";
 import { insertVideoSchema, insertVideoWithTagsSchema, insertVideoViewSchema, insertCreditTransactionSchema, insertVideoFavoriteSchema, insertDemoLinkClickSchema } from "@shared/schema";
 import { z } from "zod";
 import Stripe from "stripe";
+import { scrapeProductPage, ScrapeError } from "./scraper";
 
 if (!process.env.STRIPE_SECRET_KEY) {
   throw new Error('Missing required Stripe secret: STRIPE_SECRET_KEY');
@@ -207,6 +208,119 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(400).json({ message: "Invalid video data", errors: error.errors });
       }
       res.status(500).json({ message: "Failed to create video" });
+    }
+  });
+
+  app.post('/api/videos/scrape-url', isAuthenticated, async (req: any, res) => {
+    try {
+      const { url } = req.body ?? {};
+      if (!url || typeof url !== 'string') {
+        return res.status(400).json({ message: 'A valid URL is required.' });
+      }
+
+      const scrapeResult = await scrapeProductPage(url);
+      res.json(scrapeResult);
+    } catch (error) {
+      if (error instanceof ScrapeError) {
+        return res.status(400).json({ message: error.message });
+      }
+      console.error('Error scraping URL:', error);
+      res.status(500).json({ message: 'Failed to scrape the provided URL.' });
+    }
+  });
+
+  app.post('/api/videos/import-from-url', isAuthenticated, async (req: any, res) => {
+    const userId = req.user.claims.sub;
+    const { sourceUrl, preferredVideoUrl, overrides, tags: rawTags } = req.body ?? {};
+
+    if (!sourceUrl || typeof sourceUrl !== 'string') {
+      return res.status(400).json({ message: 'sourceUrl is required.' });
+    }
+
+    try {
+      const scrapeResult = await scrapeProductPage(sourceUrl);
+      const availableVideos = scrapeResult.videoSources;
+
+      if (!availableVideos.length) {
+        return res.status(422).json({ message: 'No downloadable demo videos were found on this page.' });
+      }
+
+      let chosenVideo = availableVideos[0];
+      if (preferredVideoUrl && typeof preferredVideoUrl === 'string') {
+        const match = availableVideos.find(video => video.url === preferredVideoUrl.trim());
+        if (match) {
+          chosenVideo = match;
+        }
+      }
+
+      const sanitizeText = (value: unknown): string | undefined => {
+        if (typeof value !== 'string') return undefined;
+        const trimmed = value.trim();
+        return trimmed.length > 0 ? trimmed : undefined;
+      };
+
+      const explicitTitle = sanitizeText(overrides?.title);
+      const explicitDescription = sanitizeText(overrides?.description);
+      const explicitProductUrl = sanitizeText(overrides?.productUrl);
+      const explicitThumbnail = sanitizeText(overrides?.thumbnailUrl);
+
+      const defaultTitle = scrapeResult.title ?? `Imported demo from ${new URL(scrapeResult.originalUrl).hostname}`;
+      const defaultDescription = scrapeResult.description ?? `Demo imported from ${scrapeResult.originalUrl}`;
+      const defaultProductUrl = scrapeResult.canonicalUrl ?? scrapeResult.originalUrl;
+
+      const tagSet = new Set<string>();
+      if (Array.isArray(rawTags)) {
+        for (const tag of rawTags) {
+          if (typeof tag === 'string') {
+            const trimmed = tag.trim();
+            if (trimmed) {
+              tagSet.add(trimmed.slice(0, 50));
+            }
+          }
+        }
+      }
+
+      for (const tag of scrapeResult.tags) {
+        if (typeof tag === 'string') {
+          const trimmed = tag.trim();
+          if (trimmed) {
+            tagSet.add(trimmed.slice(0, 50));
+          }
+        }
+      }
+
+      const combinedTags = Array.from(tagSet).slice(0, 10);
+
+      const videoPayload = insertVideoWithTagsSchema.parse({
+        title: explicitTitle ?? defaultTitle,
+        description: explicitDescription ?? defaultDescription,
+        productUrl: explicitProductUrl ?? defaultProductUrl,
+        videoPath: chosenVideo.url,
+        thumbnailPath: explicitThumbnail ?? scrapeResult.thumbnailUrl,
+        creatorId: userId,
+        provider: chosenVideo.type === 'hls' ? 'stream' : 's3',
+        hls_url: chosenVideo.type === 'hls' ? chosenVideo.url : undefined,
+        duration_s: scrapeResult.durationSeconds,
+        tags: combinedTags,
+        status: 'ready',
+      });
+
+      const video = await storage.createVideoWithTags(videoPayload);
+
+      res.status(201).json({
+        video,
+        metadata: scrapeResult,
+        selectedVideo: chosenVideo,
+      });
+    } catch (error) {
+      if (error instanceof ScrapeError) {
+        return res.status(400).json({ message: error.message });
+      }
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ message: 'Invalid video data generated from scrape', errors: error.errors });
+      }
+      console.error('Error importing video from URL:', error);
+      res.status(500).json({ message: 'Failed to import video from the provided URL.' });
     }
   });
 

--- a/server/scraper.ts
+++ b/server/scraper.ts
@@ -1,0 +1,650 @@
+import { setTimeout as setTimeoutPromise } from "timers/promises";
+
+const FETCH_TIMEOUT_MS = 10000;
+const USER_AGENT = "ShipShowScraper/1.0 (+https://shipshow.io)";
+
+export type VideoSourceType = "file" | "hls" | "unknown";
+
+export interface ScrapedVideoSource {
+  url: string;
+  type: VideoSourceType;
+  label?: string;
+  mimeType?: string;
+}
+
+export interface ScrapeResult {
+  originalUrl: string;
+  canonicalUrl?: string;
+  title?: string;
+  description?: string;
+  thumbnailUrl?: string;
+  tags: string[];
+  videoSources: ScrapedVideoSource[];
+  durationSeconds?: number;
+}
+
+export class ScrapeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ScrapeError";
+  }
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (_, entity: string) => {
+    const lower = entity.toLowerCase();
+    switch (lower) {
+      case "amp":
+        return "&";
+      case "lt":
+        return "<";
+      case "gt":
+        return ">";
+      case "quot":
+        return '"';
+      case "apos":
+      case "#39":
+        return "'";
+      case "nbsp":
+        return " ";
+      default:
+        if (lower.startsWith("#x")) {
+          const codePoint = Number.parseInt(lower.slice(2), 16);
+          if (!Number.isNaN(codePoint)) {
+            return String.fromCodePoint(codePoint);
+          }
+        } else if (lower.startsWith("#")) {
+          const codePoint = Number.parseInt(lower.slice(1), 10);
+          if (!Number.isNaN(codePoint)) {
+            return String.fromCodePoint(codePoint);
+          }
+        }
+        return `&${entity};`;
+    }
+  });
+}
+
+function parseAttributes(tag: string): Record<string, string> {
+  const attributes: Record<string, string> = {};
+  const attrRegex = /([a-zA-Z0-9_:-]+)\s*=\s*("[^"]*"|'[^']*')/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = attrRegex.exec(tag)) !== null) {
+    const name = match[1].toLowerCase();
+    const rawValue = match[2];
+    const value = rawValue.slice(1, -1);
+    attributes[name] = decodeHtmlEntities(value.trim());
+  }
+
+  return attributes;
+}
+
+function toAbsoluteUrl(baseUrl: string, possibleUrl?: string): string | undefined {
+  if (!possibleUrl) return undefined;
+  try {
+    return new URL(possibleUrl, baseUrl).toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function inferVideoType(url: string, mimeType?: string): VideoSourceType {
+  const normalizedUrl = url.toLowerCase();
+  const normalizedMime = mimeType?.toLowerCase() ?? "";
+
+  if (normalizedMime.includes("m3u8") || normalizedUrl.includes(".m3u8")) {
+    return "hls";
+  }
+
+  if (
+    normalizedMime.includes("mp4") ||
+    normalizedMime.includes("webm") ||
+    normalizedMime.includes("quicktime") ||
+    normalizedUrl.includes(".mp4") ||
+    normalizedUrl.includes(".webm") ||
+    normalizedUrl.includes(".mov") ||
+    normalizedUrl.includes(".m4v")
+  ) {
+    return "file";
+  }
+
+  return "unknown";
+}
+
+function parseISODuration(value: string): number | undefined {
+  const isoRegex = /P(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?/i;
+  const match = isoRegex.exec(value);
+  if (!match) {
+    return undefined;
+  }
+  const hours = match[1] ? Number.parseFloat(match[1]) : 0;
+  const minutes = match[2] ? Number.parseFloat(match[2]) : 0;
+  const seconds = match[3] ? Number.parseFloat(match[3]) : 0;
+  const totalSeconds = hours * 3600 + minutes * 60 + seconds;
+  return Number.isFinite(totalSeconds) && totalSeconds > 0 ? Math.round(totalSeconds) : undefined;
+}
+
+function addDurationCandidate(value: unknown, container: number[]): void {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    container.push(Math.round(value));
+    return;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+
+    const directNumber = Number.parseFloat(trimmed);
+    if (Number.isFinite(directNumber) && directNumber > 0) {
+      container.push(Math.round(directNumber));
+      return;
+    }
+
+    const isoDuration = parseISODuration(trimmed);
+    if (isoDuration) {
+      container.push(isoDuration);
+    }
+  }
+}
+
+function collectKeywords(rawValue: unknown, keywords: Set<string>): void {
+  if (!rawValue) return;
+
+  if (Array.isArray(rawValue)) {
+    for (const item of rawValue) {
+      collectKeywords(item, keywords);
+    }
+    return;
+  }
+
+  if (typeof rawValue !== "string") return;
+
+  const parts = rawValue
+    .split(/[,|#]/)
+    .map(part => part.trim())
+    .filter(Boolean);
+
+  for (const part of parts) {
+    if (part.length <= 50) {
+      keywords.add(part);
+    } else {
+      keywords.add(part.slice(0, 50));
+    }
+  }
+}
+
+interface VideoSourceDraft {
+  url: string;
+  type: VideoSourceType;
+  label?: string;
+  mimeType?: string;
+}
+
+function addVideoSource(
+  baseUrl: string,
+  value: string | undefined,
+  options: { label?: string; mimeType?: string; explicitType?: VideoSourceType } | undefined,
+  container: Map<string, VideoSourceDraft>,
+): void {
+  if (!value) return;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.startsWith("data:")) return;
+
+  const absolute = toAbsoluteUrl(baseUrl, decodeHtmlEntities(trimmed));
+  if (!absolute) return;
+
+  const normalized = absolute.replace(/&amp;/g, "&");
+
+  if (container.has(normalized)) {
+    const existing = container.get(normalized)!;
+    if (options?.label && !existing.label) {
+      existing.label = options.label;
+    }
+    if (options?.mimeType && !existing.mimeType) {
+      existing.mimeType = options.mimeType;
+    }
+    if (options?.explicitType && existing.type === "unknown") {
+      existing.type = options.explicitType;
+    }
+    return;
+  }
+
+  const type = options?.explicitType ?? inferVideoType(normalized, options?.mimeType);
+  container.set(normalized, {
+    url: normalized,
+    type,
+    label: options?.label,
+    mimeType: options?.mimeType,
+  });
+}
+
+function processJsonLdNode(
+  node: any,
+  baseUrl: string,
+  titleCandidates: string[],
+  descriptionCandidates: string[],
+  thumbnailCandidates: string[],
+  keywords: Set<string>,
+  videoDrafts: Map<string, VideoSourceDraft>,
+  durationCandidates: number[],
+  visited: Set<any>,
+): void {
+  if (!node || typeof node !== "object") return;
+  if (visited.has(node)) return;
+  visited.add(node);
+
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      processJsonLdNode(
+        item,
+        baseUrl,
+        titleCandidates,
+        descriptionCandidates,
+        thumbnailCandidates,
+        keywords,
+        videoDrafts,
+        durationCandidates,
+        visited,
+      );
+    }
+    return;
+  }
+
+  const typeValue = (node["@type"] || node["type"])?.toString().toLowerCase();
+
+  if (typeValue === "videoobject") {
+    if (typeof node.name === "string") {
+      titleCandidates.push(node.name.trim());
+    }
+    if (typeof node.description === "string") {
+      descriptionCandidates.push(node.description.trim());
+    }
+    if (node.thumbnailUrl) {
+      const thumb = Array.isArray(node.thumbnailUrl) ? node.thumbnailUrl[0] : node.thumbnailUrl;
+      if (typeof thumb === "string") {
+        const absoluteThumb = toAbsoluteUrl(baseUrl, thumb.trim());
+        if (absoluteThumb) {
+          thumbnailCandidates.push(absoluteThumb);
+        }
+      }
+    }
+    if (node.duration) {
+      addDurationCandidate(node.duration, durationCandidates);
+    }
+    if (node.encodingFormat && typeof node.encodingFormat === "string") {
+      // Encoding format may help refine mime type later
+    }
+    if (node.contentUrl && typeof node.contentUrl === "string") {
+      addVideoSource(
+        baseUrl,
+        node.contentUrl,
+        {
+          label: typeof node.name === "string" ? node.name : "Video",
+          mimeType: typeof node.encodingFormat === "string" ? node.encodingFormat : undefined,
+        },
+        videoDrafts,
+      );
+    }
+    if (node.embedUrl && typeof node.embedUrl === "string") {
+      const inferredType = inferVideoType(node.embedUrl, typeof node.encodingFormat === "string" ? node.encodingFormat : undefined);
+      if (inferredType !== "unknown") {
+        addVideoSource(
+          baseUrl,
+          node.embedUrl,
+          {
+            label: typeof node.name === "string" ? node.name : "Video",
+            mimeType: typeof node.encodingFormat === "string" ? node.encodingFormat : undefined,
+            explicitType: inferredType,
+          },
+          videoDrafts,
+        );
+      }
+    }
+    if (node.keywords) {
+      collectKeywords(node.keywords, keywords);
+    }
+  }
+
+  if (typeValue === "product") {
+    if (typeof node.name === "string") {
+      titleCandidates.push(node.name.trim());
+    }
+    if (typeof node.description === "string") {
+      descriptionCandidates.push(node.description.trim());
+    }
+    if (node.image) {
+      const imageValue = Array.isArray(node.image) ? node.image[0] : node.image;
+      if (typeof imageValue === "string") {
+        const absolute = toAbsoluteUrl(baseUrl, imageValue);
+        if (absolute) {
+          thumbnailCandidates.push(absolute);
+        }
+      }
+    }
+    if (node.brand && typeof node.brand === "object" && typeof node.brand.name === "string") {
+      collectKeywords(node.brand.name, keywords);
+    }
+  }
+
+  // Recursively process known nested properties that may contain useful info
+  const nestedKeys = [
+    "video",
+    "hasVideo",
+    "itemListElement",
+    "associatedMedia",
+    "subjectOf",
+    "mentions",
+    "offers",
+    "potentialAction",
+    "mainEntity",
+  ];
+
+  for (const key of nestedKeys) {
+    if (key in node) {
+      processJsonLdNode(
+        node[key],
+        baseUrl,
+        titleCandidates,
+        descriptionCandidates,
+        thumbnailCandidates,
+        keywords,
+        videoDrafts,
+        durationCandidates,
+        visited,
+      );
+    }
+  }
+
+  // As a fallback, traverse any object properties that are likely to contain nested JSON-LD
+  for (const value of Object.values(node)) {
+    if (typeof value === "object" && value !== null) {
+      processJsonLdNode(
+        value,
+        baseUrl,
+        titleCandidates,
+        descriptionCandidates,
+        thumbnailCandidates,
+        keywords,
+        videoDrafts,
+        durationCandidates,
+        visited,
+      );
+    }
+  }
+}
+
+function chooseFirst<T>(values: Array<T | undefined | null>): T | undefined {
+  for (const value of values) {
+    if (typeof value === "string") {
+      const trimmed = (value as string).trim();
+      if (trimmed) return trimmed as T;
+    } else if (value !== undefined && value !== null) {
+      return value as T;
+    }
+  }
+  return undefined;
+}
+
+export async function scrapeProductPage(targetUrl: string): Promise<ScrapeResult> {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(targetUrl);
+  } catch {
+    throw new ScrapeError("Invalid URL provided. Please enter a valid URL including the protocol (e.g., https://example.com)");
+  }
+
+  const controller = new AbortController();
+  const timeoutPromise = setTimeoutPromise(FETCH_TIMEOUT_MS, undefined, { signal: controller.signal }).catch(() => {
+    controller.abort();
+  });
+
+  let response: Response;
+  try {
+    response = await fetch(parsedUrl.toString(), {
+      signal: controller.signal,
+      redirect: "follow",
+      headers: {
+        "User-Agent": USER_AGENT,
+        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      },
+    });
+  } catch (error: any) {
+    if (error?.name === "AbortError") {
+      throw new ScrapeError("Timed out while trying to load the page. Please try again or use a different URL.");
+    }
+    throw new ScrapeError(`Failed to fetch the provided URL: ${error?.message ?? "Unknown error"}`);
+  } finally {
+    controller.abort();
+    await timeoutPromise.catch(() => undefined);
+  }
+
+  if (!response.ok) {
+    throw new ScrapeError(`Failed to fetch the provided URL (status ${response.status}).`);
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("text/html") && !contentType.includes("application/xhtml")) {
+    throw new ScrapeError("The provided URL does not appear to be an HTML page.");
+  }
+
+  const html = await response.text();
+
+  const titleCandidates: string[] = [];
+  const descriptionCandidates: string[] = [];
+  const thumbnailCandidates: string[] = [];
+  const keywords = new Set<string>();
+  const videoDrafts = new Map<string, VideoSourceDraft>();
+  const durationCandidates: number[] = [];
+
+  const metaRegex = /<meta\b[^>]*>/gi;
+  let metaMatch: RegExpExecArray | null;
+
+  while ((metaMatch = metaRegex.exec(html)) !== null) {
+    const attrs = parseAttributes(metaMatch[0]);
+    const name = attrs["name"]?.toLowerCase();
+    const property = attrs["property"]?.toLowerCase();
+    const itemprop = attrs["itemprop"]?.toLowerCase();
+    const content = attrs["content"]?.trim();
+
+    if (!content) continue;
+
+    if (property === "og:title" || name === "twitter:title" || itemprop === "name" || name === "title") {
+      titleCandidates.push(content);
+    }
+
+    if (
+      property === "og:description" ||
+      name === "description" ||
+      name === "twitter:description" ||
+      itemprop === "description" ||
+      property === "product:description"
+    ) {
+      descriptionCandidates.push(content);
+    }
+
+    if (
+      property === "og:image" ||
+      property === "og:image:url" ||
+      name === "twitter:image" ||
+      itemprop === "image" ||
+      itemprop === "thumbnailurl"
+    ) {
+      const absolute = toAbsoluteUrl(parsedUrl.toString(), content);
+      if (absolute) {
+        thumbnailCandidates.push(absolute);
+      }
+    }
+
+    if (name === "keywords" || itemprop === "keywords") {
+      collectKeywords(content, keywords);
+    }
+
+    if (property?.endsWith(":tag") || name?.endsWith(":tag")) {
+      collectKeywords(content, keywords);
+    }
+
+    if (property === "og:video" || property === "og:video:url" || property === "og:video:secure_url") {
+      addVideoSource(parsedUrl.toString(), content, { label: "OpenGraph video" }, videoDrafts);
+    }
+
+    if (property === "og:video:type" || name === "twitter:player:stream:content_type") {
+      // Could refine MIME type if paired with URL later
+    }
+
+    if (property === "og:video:duration" || property === "video:duration" || name === "duration") {
+      addDurationCandidate(content, durationCandidates);
+    }
+
+    if (name === "twitter:player:stream" || name === "twitter:player:stream:src") {
+      addVideoSource(parsedUrl.toString(), content, { label: "Twitter video" }, videoDrafts);
+    }
+  }
+
+  const linkRegex = /<link\b[^>]*>/gi;
+  let canonicalUrl: string | undefined;
+  let linkMatch: RegExpExecArray | null;
+
+  while ((linkMatch = linkRegex.exec(html)) !== null) {
+    const attrs = parseAttributes(linkMatch[0]);
+    const rel = attrs["rel"]?.toLowerCase();
+    if (rel === "canonical" && attrs["href"]) {
+      const absolute = toAbsoluteUrl(parsedUrl.toString(), attrs["href"]);
+      if (absolute) {
+        canonicalUrl = absolute;
+        break;
+      }
+    }
+  }
+
+  const titleMatch = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html);
+  if (titleMatch && titleMatch[1]) {
+    titleCandidates.push(decodeHtmlEntities(titleMatch[1].trim()));
+  }
+
+  const videoBlockRegex = /<video\b([\s\S]*?)<\/video>/gi;
+  let videoMatch: RegExpExecArray | null;
+  let inlineVideoIndex = 0;
+
+  while ((videoMatch = videoBlockRegex.exec(html)) !== null) {
+    inlineVideoIndex += 1;
+    const videoTag = `<video${videoMatch[1]}>`;
+    const videoAttrs = parseAttributes(videoTag);
+    if (videoAttrs["poster"]) {
+      const absolutePoster = toAbsoluteUrl(parsedUrl.toString(), videoAttrs["poster"]);
+      if (absolutePoster) {
+        thumbnailCandidates.push(absolutePoster);
+      }
+    }
+    if (videoAttrs["src"]) {
+      addVideoSource(
+        parsedUrl.toString(),
+        videoAttrs["src"],
+        { label: `Inline video ${inlineVideoIndex}` },
+        videoDrafts,
+      );
+    }
+
+    const sources = videoMatch[0].match(/<source\b[^>]*>/gi) ?? [];
+    let sourceIndex = 0;
+    for (const sourceTag of sources) {
+      sourceIndex += 1;
+      const sourceAttrs = parseAttributes(sourceTag);
+      if (sourceAttrs["src"]) {
+        addVideoSource(
+          parsedUrl.toString(),
+          sourceAttrs["src"],
+          {
+            label: sourceAttrs["label"] ?? `Video source ${inlineVideoIndex}.${sourceIndex}`,
+            mimeType: sourceAttrs["type"],
+          },
+          videoDrafts,
+        );
+      }
+    }
+  }
+
+  const jsonLdRegex = /<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  let jsonMatch: RegExpExecArray | null;
+
+  while ((jsonMatch = jsonLdRegex.exec(html)) !== null) {
+    const raw = jsonMatch[1]?.trim();
+    if (!raw) continue;
+
+    const cleaned = raw.replace(/<!--([\s\S]*?)-->/g, "").trim();
+    if (!cleaned) continue;
+
+    const candidates = [cleaned];
+    if (!cleaned.startsWith("[") && !cleaned.endsWith("]")) {
+      candidates.push(`[${cleaned}]`);
+    }
+
+    let parsedJson: any = undefined;
+    for (const candidate of candidates) {
+      try {
+        parsedJson = JSON.parse(candidate);
+        break;
+      } catch {
+        continue;
+      }
+    }
+
+    if (parsedJson) {
+      processJsonLdNode(
+        parsedJson,
+        parsedUrl.toString(),
+        titleCandidates,
+        descriptionCandidates,
+        thumbnailCandidates,
+        keywords,
+        videoDrafts,
+        durationCandidates,
+        new Set<any>(),
+      );
+    }
+  }
+
+  const directVideoRegex = /https?:\/\/[\w.-]+(?:\/[\w\-./%?=&]*)?\.(?:mp4|m3u8|webm|mov|m4v)(?:\?[^"'\s<>]*)?/gi;
+  let directMatch: RegExpExecArray | null;
+  while ((directMatch = directVideoRegex.exec(html)) !== null) {
+    const candidate = directMatch[0];
+    addVideoSource(parsedUrl.toString(), candidate, { label: "Detected video" }, videoDrafts);
+  }
+
+  const durationMetaRegex = /data-duration\s*=\s*("[^"]*"|'[^']*')/gi;
+  let durationMatch: RegExpExecArray | null;
+  while ((durationMatch = durationMetaRegex.exec(html)) !== null) {
+    const value = durationMatch[1]?.slice(1, -1);
+    if (value) {
+      addDurationCandidate(value, durationCandidates);
+    }
+  }
+
+  const title = chooseFirst(titleCandidates);
+  const description = chooseFirst(descriptionCandidates);
+  const thumbnailUrl = chooseFirst(thumbnailCandidates);
+  const durationSeconds = chooseFirst(durationCandidates);
+
+  const filteredVideos = Array.from(videoDrafts.values()).filter(source => source.type !== "unknown");
+
+  filteredVideos.sort((a, b) => {
+    if (a.type === b.type) return 0;
+    if (a.type === "file" && b.type === "hls") return -1;
+    if (a.type === "hls" && b.type === "file") return 1;
+    if (a.type === "file") return -1;
+    if (b.type === "file") return 1;
+    return 0;
+  });
+
+  const uniqueTags = Array.from(keywords).slice(0, 20);
+
+  return {
+    originalUrl: parsedUrl.toString(),
+    canonicalUrl,
+    title,
+    description,
+    thumbnailUrl,
+    tags: uniqueTags,
+    videoSources: filteredVideos,
+    durationSeconds,
+  };
+}


### PR DESCRIPTION
## Summary
- add an HTML scraping utility that gathers metadata, keywords, and downloadable video sources from product URLs to power auto-imports
- expose authenticated endpoints to scrape a page and import a demo record directly from a URL using the scraped details
- extend the submit demo flow with an "Import from URL" option that scans pages, prefills form fields, and lets creators choose a detected video source

## Testing
- npm run check *(fails: existing type errors in unrelated components)*

------
https://chatgpt.com/codex/tasks/task_e_68c8c1bb616483208d6442bdf4ad6b91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a two-mode submission flow: upload a file or import from a web page.
  * New “Import from URL” option scans a page, detects downloadable videos, and lets you pick one to import.
  * Auto-fills title, description, thumbnail, tags, and duration from the scanned page, with manual overrides.
  * Enhanced toasts and status indicators for scanning, importing, uploading, and submitting.
  * Updated UI with tabs, video preview/selector, and clearer action buttons that reflect the current operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->